### PR TITLE
Run local

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start-local": "REACT_APP_LOCAL=1 react-scripts start",    
     "start-pc": "set PORT=3001&& react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --forceExit --env=jsdom",

--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,7 @@ class App extends Component {
       // Log it to console to make sure the dev is aware ;)
       /* eslint-disable-next-line */
       console.log('Using local Deepstream host');
-      settings.communication.host_ip = 'localhost';
+      settings.communication.host_ip = 'localhost:60020';
     }
     this.com = new Communication(settings.communication, onConnect);
   }

--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,12 @@ class App extends Component {
   constructor(props) {
     super(props);
 
+    if (process.env.REACT_APP_LOCAL) {
+      console.log('Using local Deepstream host');
+    } else {
+      console.log('Using remote Deepstream host');
+    }
+
     this.state = {
       gameActive: false,
     };
@@ -38,7 +44,6 @@ class App extends Component {
       settings.communication.host_ip = undefined;
     }
     this.com = new Communication(settings.communication, onConnect);
-    
   }
 
   setGameActive() {

--- a/src/App.js
+++ b/src/App.js
@@ -24,12 +24,6 @@ class App extends Component {
   constructor(props) {
     super(props);
 
-    if (process.env.REACT_APP_LOCAL) {
-      console.log('Using local Deepstream host');
-    } else {
-      console.log('Using remote Deepstream host');
-    }
-
     this.state = {
       gameActive: false,
     };
@@ -42,6 +36,12 @@ class App extends Component {
     // to get stuck when connecting.
     if (props.test) {
       settings.communication.host_ip = undefined;
+    } else if (process.env.REACT_APP_LOCAL) {
+      // Use local deepstream server instead of Cybercom's
+      // Log it to console to make sure the dev is aware ;)
+      /* eslint-disable-next-line */
+      console.log('Using local Deepstream host');
+      settings.communication.host_ip = 'localhost';
     }
     this.com = new Communication(settings.communication, onConnect);
   }


### PR DESCRIPTION
Makes it possible to use a local deepstream server by simply running another yarn command, makes us not having the change the ip in the config file each time we want to use our own server.