### PR TITLE
Add phasing to entities

### DIFF
--- a/src/game/CollisionHandler.js
+++ b/src/game/CollisionHandler.js
@@ -10,7 +10,21 @@ class CollisionHandler {
 
   // Handle collisions between entities
   handleCollisions(dt) {
-    const groups = {};
+    const entities = this.entityHandler.getEntities();
+    let entity1;
+    let entity2;
+    for (let j = 0; j < entities.length; j += 1) {
+      entity1 = entities[j];
+      if (entity1.colliding) {
+        for (let k = j + 1; k < entities.length; k += 1) {
+          entity2 = entities[k];
+          if (entity2.colliding && entity1.collisionGroup !== entity2.collisionGroup) {
+            entity1.collision.checkCollision(entity2.collision, dt);
+          }
+        }
+      }
+    }
+    /* const groups = {};
     let entity;
     const entities = this.entityHandler.getEntities();
     for (let i = 0; i < entities.length; i += 1) {
@@ -37,7 +51,7 @@ class CollisionHandler {
           }
         }
       }
-    }
+    } */
   }
 }
 

--- a/src/game/entities/GameEntity.js
+++ b/src/game/entities/GameEntity.js
@@ -32,8 +32,9 @@ class GameEntity {
     // this.maxVelocity = 100; // Maybe do max kinetic energy?
 
     // Collision group
-    // The entity will only collide with entities with the same group number.
+    // The entity will not collide with entities in the same group.
     this.collisionGroup = 0;
+    this.colliding = true;
 
     this.listeners = [];
 
@@ -41,6 +42,7 @@ class GameEntity {
     this.phaseTimer = 2;
     this.blinkSpeed = Math.PI * 7;
     this.phasing = false;
+    this.phaseGroup = 0;
   }
 
   die() {
@@ -98,7 +100,8 @@ class GameEntity {
       if (this.phaseTimer < 0) {
         this.alpha = 1;
         this.phasing = false;
-        this.collisionGroup += 1;
+        this.collisionGroup = this.phaseGroup;
+        this.colliding = true;
       }
     }
   }
@@ -136,7 +139,9 @@ class GameEntity {
   phase(time) {
     this.phasing = true;
     this.phaseTimer = time;
-    this.collisionGroup -= 1;
+    this.phaseGroup = this.collisionGroup;
+    this.collisionGroup = -1;
+    this.colliding = false;
   }
 
   // Assume all entities aren't players and let the player objects override this.

--- a/src/game/entities/GameEntity.js
+++ b/src/game/entities/GameEntity.js
@@ -36,6 +36,11 @@ class GameEntity {
     this.collisionGroup = 0;
 
     this.listeners = [];
+
+    // Phasing
+    this.phaseTimer = 2;
+    this.blinkSpeed = Math.PI * 7;
+    this.phasing = false;
   }
 
   die() {
@@ -86,6 +91,16 @@ class GameEntity {
     this.graphic.y = this.y;
 
     this.graphic.rotation = this.rotation;
+
+    if (this.phasing) {
+      this.phaseTimer -= dt;
+      this.graphic.alpha = 0.6 + 0.4 * Math.cos(this.phaseTimer * this.blinkSpeed);
+      if (this.phaseTimer < 0) {
+        this.alpha = 1;
+        this.phasing = false;
+        this.collisionGroup += 1;
+      }
+    }
   }
 
   // Return the predicted next position
@@ -115,6 +130,13 @@ class GameEntity {
 
   addEntityListener(listener) {
     this.listeners.push(listener);
+  }
+
+  // Activate phasing
+  phase(time) {
+    this.phasing = true;
+    this.phaseTimer = time;
+    this.collisionGroup -= 1;
   }
 
   // Assume all entities aren't players and let the player objects override this.

--- a/src/game/gamemodes/Gamemode.js
+++ b/src/game/gamemodes/Gamemode.js
@@ -21,6 +21,10 @@ class Gamemode {
         localPlayer.setColor(0xee6666);
         localPlayer.y = 300;
       });
+      this.onPlayerJoin({ iconID: 2, id: 'local2' }, localPlayer => {
+        localPlayer.setColor(0xeeff66);
+        localPlayer.y = 350;
+      });
     }
   }
   /* eslint-enable class-methods-use-this, no-unused-vars, no-useless-constructor,

--- a/src/game/gamemodes/KnockOff.js
+++ b/src/game/gamemodes/KnockOff.js
@@ -2,7 +2,7 @@ import * as PIXI from 'pixi.js';
 import Gamemode from './Gamemode';
 
 // Respawn time in seconds
-const RESPAWN_TIME = 3;
+const RESPAWN_TIME = 1;
 
 // The max time between a collision and a player dying in order to count as a kill.
 const TAG_TIME = 4;
@@ -24,6 +24,7 @@ class KnockOff extends Gamemode {
     this.arenaRadius = 350;
     this.arenaCenterx = 500;
     this.arenaCentery = 500;
+    this.respawnArea = 50;
 
     // Set up arena graphic
     const graphic = new PIXI.Graphics();
@@ -86,6 +87,8 @@ class KnockOff extends Gamemode {
     circle.setColor(0xff3333);
     this.game.entityHandler.register(circle);
 
+    circle.phase(3);
+
     this.players[idTag] = circle;
     this.score[idTag] = 0;
     this.tags[idTag] = [];
@@ -124,10 +127,12 @@ class KnockOff extends Gamemode {
 
   // Called when an entity is respawned.
   onRespawn(entity) {
-    // Move the entity to the center
-    entity.x = this.arenaCenterx;
-    entity.y = this.arenaCentery;
-    // TODO: randomize a bit
+    // Move the entity close to the center
+    entity.x = this.arenaCenterx + Math.cos(Math.random() * Math.PI * 2) * this.respawnArea;
+    entity.y = this.arenaCentery + Math.sin(Math.random() * Math.PI * 2) * this.respawnArea;
+
+    // Phase the entity for a bit
+    entity.phase(2);
   }
 
   // Called when an entity dies.

--- a/src/game/gamemodes/KnockOff.js
+++ b/src/game/gamemodes/KnockOff.js
@@ -90,6 +90,8 @@ class KnockOff extends Gamemode {
     circle.setColor(0xff3333);
     this.game.entityHandler.register(circle);
 
+    circle.collisionGroup = idTag;
+
     circle.phase(3);
 
     this.players[idTag] = circle;


### PR DESCRIPTION
A phased entity will move down one collision group and phase in and out by modifying the transparency of the entity. This will give players a moment to find themselves before they start colliding again.