### PR TITLE
Resize window

### DIFF
--- a/src/components/StartMenu.js
+++ b/src/components/StartMenu.js
@@ -12,7 +12,7 @@ class StartMenu extends Component {
     super(props);
 
     this.state = {
-      menu: 'first'
+      menu: 'first',
     };
 
     this.showCreate = this.showCreate.bind(this);
@@ -42,6 +42,7 @@ class StartMenu extends Component {
   }
 
   render() {
+    // eslint-disable-next-line
     console.log(this.state.menu);
     const menus = {
       first: <FirstMenu showCreate={this.showCreate} showAbout={this.showAbout} />,

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ Configuration file for different project parameters.
 */
 
 const settings = {
-  skipmenu: false,
+  skipmenu: true,
   defaultGamemode: 'knockOff',
   game: {
     localPlayer: true,

--- a/src/game/Game.js
+++ b/src/game/Game.js
@@ -20,6 +20,12 @@ class Game {
       this.instance.addInstanceListener(this);
     }
 
+    // Resize listener
+    this.notifyResizeListeners = this.notifyResizeListeners.bind(this);
+    this.resizeListeners = [];
+    this.registerResizeListener(this);
+    window.onresize = this.notifyResizeListeners;
+
     // Create all handlers
     this.entityHandler = new EntityHandler();
     this.collisionHandler = new CollisionHandler(this.entityHandler);
@@ -71,6 +77,20 @@ class Game {
 
   // eslint-disable-next-line
   onButtonPressed(id, button) {}
+
+  registerResizeListener(listener) {
+    this.resizeListeners.push(listener);
+  }
+
+  notifyResizeListeners() {
+    this.resizeListeners.forEach(listener => {
+      listener.onWindowResize();
+    });
+  }
+
+  onWindowResize() {
+    this.app.renderer.resize(window.innerWidth, window.innerHeight);
+  }
 }
 
 export default Game;

--- a/src/game/GamemodeHandler.js
+++ b/src/game/GamemodeHandler.js
@@ -14,7 +14,7 @@ class GMHandlerClass {
       knockOff: KnockOff,
       knockOffRandom: KnockOffRandom,
       knockOffDynamic: KnockOffDynamic,
-      testGamemode: TestGamemode
+      testGamemode: TestGamemode,
     };
 
     if (settings.skipmenu) {
@@ -77,7 +77,7 @@ const GamemodeHandler = (() => {
       }
 
       return instance;
-    }
+    },
   };
 })();
 

--- a/src/game/gamemodes/Gamemode.js
+++ b/src/game/gamemodes/Gamemode.js
@@ -12,6 +12,9 @@ class Gamemode {
   no-empty-function */
   constructor(game) {
     this.game = game;
+
+    this.onWindowResize = this.onWindowResize.bind(this);
+    window.onresize = this.onWindowResize;
   }
 
   init() {
@@ -69,6 +72,10 @@ class Gamemode {
         return;
       }
     }
+  }
+
+  onWindowResize() {
+    this.game.app.renderer.resize(window.innerWidth, window.innerHeight);
   }
 
   // Clean up after the gamemode is finished.

--- a/src/game/gamemodes/Gamemode.js
+++ b/src/game/gamemodes/Gamemode.js
@@ -12,9 +12,7 @@ class Gamemode {
   no-empty-function */
   constructor(game) {
     this.game = game;
-
-    this.onWindowResize = this.onWindowResize.bind(this);
-    window.onresize = this.onWindowResize;
+    this.game.registerResizeListener(this);
   }
 
   init() {
@@ -75,7 +73,7 @@ class Gamemode {
   }
 
   onWindowResize() {
-    this.game.app.renderer.resize(window.innerWidth, window.innerHeight);
+    console.log('Please override me :)');
   }
 
   // Clean up after the gamemode is finished.

--- a/src/game/gamemodes/Gamemode.js
+++ b/src/game/gamemodes/Gamemode.js
@@ -73,7 +73,7 @@ class Gamemode {
   }
 
   onWindowResize() {
-    console.log('Please override me :)');
+    // console.log('Please override me :)');
   }
 
   // Clean up after the gamemode is finished.

--- a/src/game/gamemodes/KnockOff.js
+++ b/src/game/gamemodes/KnockOff.js
@@ -75,6 +75,12 @@ class KnockOff extends Gamemode {
     });
   }
 
+  onWindowResize() {
+    super.onWindowResize();
+    this.arenaGraphic.x = Math.round(window.innerWidth / 2);
+    this.arenaGraphic.y = Math.round(window.innerHeight / 2);
+  }
+
   // Called when a new player has been created
   onPlayerCreated(playerObject, circle) {
     const { iconID } = playerObject;

--- a/src/game/gamemodes/KnockOff.js
+++ b/src/game/gamemodes/KnockOff.js
@@ -23,8 +23,10 @@ class KnockOff extends Gamemode {
     this.game.respawnHandler.registerRespawnListener(this);
 
     this.arenaRadius = 350;
-    this.arenaCenterx = 500;
-    this.arenaCentery = 500;
+
+    // Center arena
+    this.arenaCenterx = Math.round(window.innerWidth / 2);
+    this.arenaCentery = Math.round(window.innerHeight / 2);
 
     // Set up arena graphic
     const graphic = new PIXI.Graphics();
@@ -67,8 +69,8 @@ class KnockOff extends Gamemode {
   postUpdate(dt) {
     this.game.entityHandler.getEntities().forEach(entity => {
       if (entity.isPlayer()) {
-        const dx = this.arenaCenterx - entity.x;
-        const dy = this.arenaCentery - entity.y;
+        const dx = this.arenaGraphic.x - entity.x;
+        const dy = this.arenaGraphic.y - entity.y;
         const centerDist = Math.sqrt(dx * dx + dy * dy);
 
         if (centerDist > this.arenaRadius - entity.radius) {
@@ -76,12 +78,6 @@ class KnockOff extends Gamemode {
         }
       }
     });
-  }
-
-  onWindowResize() {
-    super.onWindowResize();
-    this.arenaGraphic.x = Math.round(window.innerWidth / 2);
-    this.arenaGraphic.y = Math.round(window.innerHeight / 2);
   }
 
   // Called when a new player has been created
@@ -152,6 +148,23 @@ class KnockOff extends Gamemode {
     } else {
       this.game.entityHandler.unregisterFully(entity);
     }
+  }
+
+  onWindowResize() {
+    const newCenterX = Math.round(window.innerWidth / 2);
+    const newCenterY = Math.round(window.innerHeight / 2);
+
+    // Calculate diff in x and y before moving everything
+    const dx = this.arenaGraphic.x - newCenterX;
+    const dy = this.arenaGraphic.y - newCenterY;
+
+    this.arenaGraphic.x = newCenterX;
+    this.arenaGraphic.y = newCenterY;
+
+    this.game.entityHandler.getEntities().forEach(entity => {
+      entity.x -= dx;
+      entity.y -= dy;
+    });
   }
 
   /* eslint-disable class-methods-use-this */

--- a/src/game/gamemodes/KnockOffDynamic.js
+++ b/src/game/gamemodes/KnockOffDynamic.js
@@ -43,6 +43,7 @@ class KnockOffDynamic extends KnockOff {
       }
     } else {
       // We can't shrink any more
+      // eslint-disable-next-line
       if (this.arenaRadius * multDec < minRadius) {
         this.expanding = true;
       } else {


### PR DESCRIPTION
Adds functionality for handling window resizing. The implementation is currently based on a notifier in Game.js which notifies listeners, which are currently just the gamemode. The initial thought was to implement the functionality in GameComponent.js but I decided against it because it was difficult to register a listener in game modes.

The onWindowResize function in the knockoff game mode currently moves places the arena in the middle and moves all entities accordingly.