### PR TITLE
add snapshot test on FirstMenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "react-dom": "^16.2.0",
     "react-scripts": "1.1.1",
     "react-spinners": "^0.2.6",
-    "react-test-renderer": "^16.3.2",
     "webfontloader": "^1.6.28"
   },
   "scripts": {
@@ -37,6 +36,7 @@
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-react": "^7.6.1",
     "eslint-plugin-standard": "^3.0.1",
+    "react-test-renderer": "^16.3.2",
     "prettier": "^1.10.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react-dom": "^16.2.0",
     "react-scripts": "1.1.1",
     "react-spinners": "^0.2.6",
+    "react-test-renderer": "^16.3.2",
     "webfontloader": "^1.6.28"
   },
   "scripts": {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -10,6 +10,8 @@ import ResourceServer from './game/ResourceServer';
 import GamemodeHandler from './game/GamemodeHandler';
 import Game from './game/Game';
 import ScoreManager from './game/ScoreManager';
+import renderer from 'react-test-renderer';
+import FirstMenu from './components/FirstMenu';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
@@ -186,5 +188,15 @@ describe('ScoreManager', () => {
     expect(list[1].score1).toBe(2);
     expect(list[0].score2).toBe(7);
     expect(list[1].score2).toBe(4);
+  });
+});
+
+describe('FirstMenu', () => {
+  it('matches the snapshot', () => {
+    var showAbout = jest.fn();
+    var showCreate = jest.fn();
+    const tree = renderer.create(<FirstMenu showCreate={showCreate} showAbout={showAbout} />).toJSON();
+    expect(tree).toMatchSnapshot();
+
   });
 });

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FirstMenu matches the snapshot 1`] = `
+<div>
+  <button
+    className="menu-button"
+    onClick={[Function]}
+  >
+    Create Game
+  </button>
+  <button
+    className="menu-button"
+    onClick={[Function]}
+  >
+    About
+  </button>
+</div>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5592,6 +5592,10 @@ react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
+react-is@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
+
 react-scripts@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-1.1.1.tgz#279d449f7311fed910506987a1ade014027788a8"
@@ -5645,6 +5649,15 @@ react-spinners@^0.2.6:
     prop-types "^15.5.10"
     react-emotion "^8.0.6"
     recompose "0.26.0"
+
+react-test-renderer@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.2"
 
 react@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
snapshot - takes snapshot of current status of Firstmenu. e.g. change text/img/position of buttons will fail test and ask if it was meant to be change, then update the snapshot by pressing u. Prevents accidental changes.