### PR TITLE
Remove trailing zeroes in highscore list

### DIFF
--- a/src/game/HighscoreList.js
+++ b/src/game/HighscoreList.js
@@ -106,7 +106,7 @@ class HighscoreList {
           if (curRow[scoreName].text !== val[scoreName].toString()) {
             let value = val[scoreName];
             if (value.toFixed) {
-              value = value.toFixed(2);
+              value = +value.toFixed(2);
             }
             curRow[scoreName].text = value;
           }
@@ -168,7 +168,7 @@ class HighscoreList {
         scores.forEach((scoreName, scoreI) => {
           let value = val[scoreName];
           if (value.toFixed) {
-            value = value.toFixed(2);
+            value = +value.toFixed(2);
           }
           const text = new PIXI.Text(value, TEXT_STYLE);
           text.x = scoreAdjust;


### PR DESCRIPTION
This will remove all trailing zeroes meaning that numbers will now display up to two decimals. However this could make columns uneven since the values in a column show varying amounts of decimals. Maybe adding a setting for the amount of decimal places to show for each scoretype would be more elegant? Feel free to add onto this pull request.