### PR TITLE
Add demo system

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,13 +7,14 @@ const settings = {
   defaultGamemode: 'Knock Off',
   game: {
     localPlayer: false,
-    dummyCount: 2,
+    dummyCount: 9,
     testLeave: false,
     testRejoin: false,
     testMove: false,
     forceCanvas: true,
     antialias: false,
-    scaleUI: false,
+    scaleUI: true,
+    demosystem: true,
   },
   communication: {
     pingrate: 1,

--- a/src/game/GamemodeConfigHandler.js
+++ b/src/game/GamemodeConfigHandler.js
@@ -4,6 +4,8 @@ import KillSystem from './configsystems/KillSystem';
 import HighscoreSystem from './configsystems/HighscoreSystem';
 import SpawnSystem from './configsystems/SpawnSystem';
 import LeaveSystem from './configsystems/LeaveSystem';
+import DemoSystem from './configsystems/DemoSystem';
+import settings from '../config';
 
 /*
 Handles a gamemode's config
@@ -27,8 +29,13 @@ class GamemodeConfigHandler {
     this.onPlayerLeaveSystems = [];
     this.onButtonPressedSystems = [];
 
-    this.injectBinds();
     this.setUpOptions();
+  }
+
+  clean() {
+    this.systems.forEach(system => {
+      system.clean();
+    });
   }
 
   getPlayerEntity(id) {
@@ -117,6 +124,12 @@ class GamemodeConfigHandler {
       this.game.app.renderer.backgroundColor = this.options.backgroundColor;
     }
 
+    // Add demo system if requested
+    if (settings.game.demosystem) {
+      this.addSystem(DemoSystem);
+    }
+
+    // Always add the leave system
     this.addSystem(LeaveSystem);
 
     // Always add the spawn system because we only have games built around this one.
@@ -127,41 +140,22 @@ class GamemodeConfigHandler {
     // After all systems have been added they should attach to hooks
     // There is no assumption about specific order this will happen in
     // so the available hooks should have already been created during setup.
-    this.systems.forEach(system => system.attachHooks());
-  }
+    this.systems.forEach(system => system.attachHooks(this));
 
-  // Injects the handler into the gamemode events allowing us to seamlessly add functionality
-  injectBinds() {
-    this.injectBind('preUpdate');
-    this.injectBind('postUpdate');
-    this.injectBind('onPlayerJoin');
-    this.injectBind('onPlayerCreated');
-    this.injectBind('onPlayerLeave');
-    this.injectBind('onButtonPressed');
-  }
-
-  // Swap a function in a gamemode with one of ours
-  injectBind(func) {
-    const temp = this.gamemode[func];
-
-    this.gamemode[func] = this[func].bind(this);
-    if (temp === undefined) {
-      this.binds[func] = () => {};
-    } else {
-      this.binds[func] = temp.bind(this.gamemode);
+    // Let the gamemode attach to hooks too
+    if (this.gamemode.attachHooks) {
+      this.gamemode.attachHooks(this);
     }
   }
 
   // Called before the physics update each loop
   preUpdate(dt) {
     this.preUpdateSystems.forEach(system => system.preUpdate(dt));
-    this.binds.preUpdate(dt);
   }
 
   // Called after the physics update
   postUpdate(dt) {
     this.postUpdateSystems.forEach(system => system.postUpdate(dt));
-    this.binds.postUpdate(dt);
   }
 
   // Called when a player joins the game
@@ -173,19 +167,17 @@ class GamemodeConfigHandler {
   // Called when a player joins the game but after they have had an entity created for them
   onPlayerCreated(playerObject, circle) {
     this.onPlayerCreatedSystems.forEach(system => system.onPlayerCreated(playerObject, circle));
-    this.binds.onPlayerCreated(playerObject, circle);
+    this.gamemode.onPlayerCreated(playerObject, circle);
   }
 
   // Called when a player leaves the game
   onPlayerLeave(id) {
     this.onPlayerLeaveSystems.forEach(system => system.onPlayerLeave(id));
-    this.binds.onPlayerLeave(id);
   }
 
   // Called when a player pressed a button
   onButtonPressed(id, button) {
     this.onButtonPressedSystems.forEach(system => system.onButtonPressed(id, button));
-    this.binds.onButtonPressed(id, button);
   }
 }
 

--- a/src/game/GamemodeHandler.js
+++ b/src/game/GamemodeHandler.js
@@ -89,7 +89,7 @@ class GMHandlerClass {
 
     return {
       SelectedMode: Gamemode,
-      requestedResources: resources,
+      resources,
       options,
     };
   }

--- a/src/game/HighscoreList.js
+++ b/src/game/HighscoreList.js
@@ -48,6 +48,10 @@ class HighscoreList {
     this.update();
   }
 
+  clean() {
+    this.container.destroy({ children: true });
+  }
+
   /*
   Paint the heading with explanations to different score types
   */

--- a/src/game/Instance.js
+++ b/src/game/Instance.js
@@ -143,6 +143,20 @@ class Instance {
   getPlayers() {
     return this.players;
   }
+
+  stashPlayers() {
+    this.stash = {};
+    Object.keys(this.players).forEach(key => {
+      this.stash[key] = this.players[key];
+    });
+  }
+
+  popStash() {
+    this.players = {};
+    Object.keys(this.stash).forEach(key => {
+      this.addPlayer(this.stash[key]);
+    });
+  }
 }
 
 export default Instance;

--- a/src/game/KeyboardManager.js
+++ b/src/game/KeyboardManager.js
@@ -69,14 +69,16 @@ class KeyboardManager {
     // Update sensor values if applicable, else check for game button presses
     if (updateSensorValues) {
       this.calcSensorChange();
-    } else if (key === '1') {
-      this.onButtonPress(0);
-    } else if (key === '2') {
-      this.onButtonPress(1);
-    } else if (key === '3') {
-      this.onButtonPress(2);
-    } else if (key === '4') {
-      this.onButtonPress(3);
+    } else if (downFlag) {
+      if (key === '1') {
+        this.onButtonPress(0);
+      } else if (key === '2') {
+        this.onButtonPress(1);
+      } else if (key === '3') {
+        this.onButtonPress(2);
+      } else if (key === '4') {
+        this.onButtonPress(3);
+      }
     }
   }
 

--- a/src/game/RespawnHandler.js
+++ b/src/game/RespawnHandler.js
@@ -142,7 +142,8 @@ class RespawnHandler {
 
   // Destroy entities waiting on respawn and disconnect listeners.
   clean() {
-    this.respawnList.forEach(entity => {
+    this.respawnList.forEach(pair => {
+      const entity = getEntity(pair);
       entity.destroy();
     });
     this.respawnList = [];

--- a/src/game/configsystems/ConfigSystem.js
+++ b/src/game/configsystems/ConfigSystem.js
@@ -13,6 +13,9 @@ class ConfigSystem {
   // Attach listener to the needed hooks
   attachHooks() {}
 
+  // Clean up consequences
+  clean() {}
+
   // Called before the physics update
   preUpdate(dt) {}
 

--- a/src/game/configsystems/DemoSystem.js
+++ b/src/game/configsystems/DemoSystem.js
@@ -1,0 +1,49 @@
+import ConfigSystem from './ConfigSystem';
+import GamemodeHandler from '../GamemodeHandler';
+
+function mod(n, m) {
+  return (n % m + m) % m;
+}
+
+/*
+Demo system, provides functionality for tweaking stuff life.
+*/
+class DemoSystem extends ConfigSystem {
+  constructor(handler, options) {
+    super(handler, options);
+
+    const gamemodeHandler = GamemodeHandler.getInstance();
+    this.gamemodes = gamemodeHandler.getGamemodes();
+    let i = -1;
+    this.gamemodes.some(element => {
+      i += 1;
+      return element === gamemodeHandler.getSelectedId();
+    });
+    this.currentIndex = i;
+
+    this.handleKeyboardInput = this.handleKeyboardInput.bind(this);
+  }
+
+  setup() {
+    window.addEventListener('keydown', this.handleKeyboardInput);
+
+    return {};
+  }
+
+  handleKeyboardInput(event) {
+    const { key } = event;
+    if (key === 'i') {
+      // Go to previous
+      this.game.switchGamemode(this.gamemodes[mod(this.currentIndex - 1, this.gamemodes.length)]);
+    } else if (key === 'o') {
+      // Go to next
+      this.game.switchGamemode(this.gamemodes[mod(this.currentIndex + 1, this.gamemodes.length)]);
+    }
+  }
+
+  clean() {
+    window.removeEventListener('keydown', this.handleKeyboardInput);
+  }
+}
+
+export default DemoSystem;

--- a/src/game/configsystems/HighscoreSystem.js
+++ b/src/game/configsystems/HighscoreSystem.js
@@ -55,7 +55,7 @@ class HighscoreSystem extends ConfigSystem {
       const { initial, primary } = score;
       this.scoreManager.addScoreType(name, initial, primary);
     });
-    this.gamemode.hs_list = new HighscoreList(this.scoreManager, this.game);
+    this.highscoreList = new HighscoreList(this.scoreManager, this.game);
 
     this.setUpHighscoreEvents();
 
@@ -73,6 +73,10 @@ class HighscoreSystem extends ConfigSystem {
     }
 
     return binds;
+  }
+
+  clean() {
+    this.highscoreList.clean();
   }
 
   attachHooks() {

--- a/src/game/configsystems/LeaveSystem.js
+++ b/src/game/configsystems/LeaveSystem.js
@@ -2,7 +2,7 @@ import * as PIXI from 'pixi.js';
 import ConfigSystem from './ConfigSystem';
 
 /*
-Handles abilities.
+Handles leaving.
 */
 class LeaveSystem extends ConfigSystem {
   constructor(handler, options) {

--- a/src/game/configsystems/SpawnSystem.js
+++ b/src/game/configsystems/SpawnSystem.js
@@ -56,7 +56,7 @@ class SpawnSystem extends ConfigSystem {
           this.game.register(circle);
 
           // Tell the gamemode (and other systems) that the player entity is ready
-          this.gamemode.onPlayerCreated(playerObject, circle);
+          this.handler.onPlayerCreated(playerObject, circle);
 
           resolve(circle);
         });

--- a/src/game/entities/BasicRectangle.js
+++ b/src/game/entities/BasicRectangle.js
@@ -18,6 +18,9 @@ class BasicRectangle extends GameEntity {
 
     // Create a graphical rectangle
     const graphic = new PIXI.Graphics();
+    graphic.beginFill(0x0);
+    graphic.drawRect(-width * 0.5 - 3, -height * 0.5 - 3, width + 6, height + 6);
+    graphic.endFill();
     graphic.beginFill(0xfffffff);
     graphic.drawRect(-width * 0.5, -height * 0.5, width, height);
     graphic.endFill();

--- a/src/game/gamemodes/DodgebotBumper.js
+++ b/src/game/gamemodes/DodgebotBumper.js
@@ -20,6 +20,7 @@ class DodgebotBumper extends Dodgebot {
     bumper.y = y;
     bumper.restitution = 2;
 
+    // If these are registered as walls then they can push the players out of the square
     this.game.register(bumper);
   }
 }

--- a/src/game/gamemodes/Gamemode.js
+++ b/src/game/gamemodes/Gamemode.js
@@ -51,10 +51,7 @@ class Gamemode {
   onWindowResize() {}
 
   // Clean up after the gamemode is finished.
-  cleanUp() {
-    this.game.entityHandler.clear();
-    this.game.respawnHandler.clean();
-  }
+  cleanUp() {}
   /* eslint-enable class-methods-use-this, no-unused-vars */
 }
 

--- a/src/game/gamemodes/Hockey.js
+++ b/src/game/gamemodes/Hockey.js
@@ -10,7 +10,7 @@ const SCALE = 300 / FONT_RESOLUTION;
 // Shuffle a list
 function shuffle(array) {
   for (let i = array.length - 1; i > 0; i -= 1) {
-    const j = Math.ceil(Math.random() * i);
+    const j = Math.floor(Math.random() * i);
     const temp = array[i];
     array[i] = array[j];
     array[j] = temp;
@@ -59,7 +59,7 @@ class Hockey extends Gamemode {
     line.restitution = 0.3;
     line.collisionGroup = 0;
     line.graphic.visible = false;
-    this.game.register(line);
+    this.game.registerWall(line);
     return line;
   }
 
@@ -84,7 +84,7 @@ class Hockey extends Gamemode {
     this.ball.resetPhysics();
     this.ball.x = 0;
     this.ball.y = 0;
-    this.ball.phase(2);
+    // this.ball.phase(2);
     this.resetPlayers();
   }
 
@@ -138,6 +138,13 @@ class Hockey extends Gamemode {
       this.team1Display.text = this.team1Score;
       this.resetBall();
     }
+
+    // Safety
+    if (this.ball.y < -this.game.gameStageHeight * 0.5) {
+      this.resetBall();
+    } else if (this.ball.y > this.game.gameStageHeight * 0.5) {
+      this.resetBall();
+    }
   }
 
   // Called when a new player has been created
@@ -179,6 +186,10 @@ class Hockey extends Gamemode {
     this.bottomLine.y = height;
     this.rightLine.x = width;
     this.leftLine.x = -width;
+  }
+
+  cleanUp() {
+    this.displayContainer.destroy({ children: true });
   }
 
   static getConfig() {

--- a/src/game/gamemodes/PassTheBomb.js
+++ b/src/game/gamemodes/PassTheBomb.js
@@ -135,11 +135,6 @@ class PassTheBomb extends Gamemode {
     circle.y = this.arenaCenterY;
   }
 
-  // Clean up after the gamemode is finished.
-  cleanUp() {
-    this.arenaGraphic.destroy();
-  }
-
   // Called when an entity is respawned.
   onPlayerRespawn(entity) {
     // Move the entity close to the center


### PR DESCRIPTION
Adds a demo system. Currently it allows switching gamemodes live.

GamemodeConfigHandler does not inject binds anymore. 
Some cleaning chains had to be fixed and some new had to be added.

Also included:
Outline on rectangles.
Hockey will reset the ball if it goes outside the screen.
Fixed shuffling on Hockey so that index 0 also gets shuffled.
Gamemodes can attach to system hooks. (Not used, just there for modularity.)